### PR TITLE
seo: fix canonical URLs to clean paths + add Open Graph tags + sitema…

### DIFF
--- a/about.html
+++ b/about.html
@@ -12,7 +12,14 @@
     <!-- Google Search Console Verification -->
     <meta name="google-site-verification" content="OqEZZ9Za0cVa9OxM45e3UE8tDv1iOWqtRXPeM1Pg_Io">
 
-    <link rel="canonical" href="https://www.onwheelsdetailing.com/about.html">
+    <link rel="canonical" href="https://www.onwheelsdetailing.com/about">
+
+    <!-- Open Graph -->
+    <meta property="og:title" content="About Us | On-Wheels Detailing">
+    <meta property="og:description" content="Learn about our passion, journey, and commitment to excellence in mobile auto detailing since 2020. Serving Harris County TX and Metro Detroit MI.">
+    <meta property="og:url" content="https://www.onwheelsdetailing.com/about">
+    <meta property="og:type" content="website">
+    <meta property="og:image" content="https://www.onwheelsdetailing.com/images/onwheelsLogo.png">
 
     <!-- Preload critical CSS -->
     <link rel="preload" as="style" href="css/style.css">

--- a/contact.html
+++ b/contact.html
@@ -12,7 +12,14 @@
     <!-- Google Search Console Verification -->
     <meta name="google-site-verification" content="OqEZZ9Za0cVa9OxM45e3UE8tDv1iOWqtRXPeM1Pg_Io">
 
-    <link rel="canonical" href="https://www.onwheelsdetailing.com/contact.html">
+    <link rel="canonical" href="https://www.onwheelsdetailing.com/contact">
+
+    <!-- Open Graph -->
+    <meta property="og:title" content="Contact On-Wheels Detailing | Free Quote">
+    <meta property="og:description" content="Get a free quote for mobile auto detailing. Call or message — serving Harris County TX and Metro Detroit MI.">
+    <meta property="og:url" content="https://www.onwheelsdetailing.com/contact">
+    <meta property="og:type" content="website">
+    <meta property="og:image" content="https://www.onwheelsdetailing.com/images/onwheelsLogo.png">
 
     <!-- Preload critical CSS -->
     <link rel="preload" as="style" href="css/style.css">

--- a/gallery.html
+++ b/gallery.html
@@ -12,7 +12,14 @@
     <!-- Google Search Console Verification -->
     <meta name="google-site-verification" content="OqEZZ9Za0cVa9OxM45e3UE8tDv1iOWqtRXPeM1Pg_Io">
 
-    <link rel="canonical" href="https://www.onwheelsdetailing.com/gallery.html">
+    <link rel="canonical" href="https://www.onwheelsdetailing.com/gallery">
+
+    <!-- Open Graph -->
+    <meta property="og:title" content="Recent Jobs | On-Wheels Detailing">
+    <meta property="og:description" content="See our work — before &amp; after results from interior detailing and paint correction jobs in TX and MI.">
+    <meta property="og:url" content="https://www.onwheelsdetailing.com/gallery">
+    <meta property="og:type" content="website">
+    <meta property="og:image" content="https://www.onwheelsdetailing.com/images/onwheelsLogo.png">
 
     <!-- Preload critical CSS -->
     <link rel="preload" as="style" href="css/style.css">

--- a/services.html
+++ b/services.html
@@ -12,7 +12,14 @@
     <!-- Google Search Console Verification -->
     <meta name="google-site-verification" content="OqEZZ9Za0cVa9OxM45e3UE8tDv1iOWqtRXPeM1Pg_Io">
 
-    <link rel="canonical" href="https://www.onwheelsdetailing.com/services.html">
+    <link rel="canonical" href="https://www.onwheelsdetailing.com/services">
+
+    <!-- Open Graph -->
+    <meta property="og:title" content="Detailing Services | On-Wheels Detailing">
+    <meta property="og:description" content="Professional mobile auto detailing — interior, paint correction &amp; ceramic coating. Serving Harris County TX and Metro Detroit MI. Free quotes.">
+    <meta property="og:url" content="https://www.onwheelsdetailing.com/services">
+    <meta property="og:type" content="website">
+    <meta property="og:image" content="https://www.onwheelsdetailing.com/images/onwheelsLogo.png">
 
     <!-- Preload critical CSS -->
     <link rel="preload" as="style" href="css/style.css">

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -7,22 +7,28 @@
         <priority>1.0</priority>
     </url>
     <url>
-        <loc>https://www.onwheelsdetailing.com/about.html</loc>
-        <lastmod>2026-07-19</lastmod>
+        <loc>https://www.onwheelsdetailing.com/about</loc>
+        <lastmod>2026-07-23</lastmod>
         <changefreq>monthly</changefreq>
-        <priority>0.8</priority>
+        <priority>0.7</priority>
     </url>
     <url>
-        <loc>https://www.onwheelsdetailing.com/services.html</loc>
+        <loc>https://www.onwheelsdetailing.com/services</loc>
         <lastmod>2026-07-23</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.9</priority>
     </url>
     <url>
-        <loc>https://www.onwheelsdetailing.com/gallery.html</loc>
+        <loc>https://www.onwheelsdetailing.com/gallery</loc>
         <lastmod>2026-07-23</lastmod>
         <changefreq>monthly</changefreq>
         <priority>0.7</priority>
+    </url>
+    <url>
+        <loc>https://www.onwheelsdetailing.com/contact</loc>
+        <lastmod>2026-07-23</lastmod>
+        <changefreq>monthly</changefreq>
+        <priority>0.8</priority>
     </url>
     <url>
         <loc>https://api.onwheelsdetailing.com/</loc>


### PR DESCRIPTION
…p sync

- Canonical: .html → clean URLs on all subpages (was causing indexing conflict)
- OG tags: title, description, url, type, image on all 4 subpages
- Sitemap: clean URLs, about priority 0.7, all lastmod 2026-07-23
- Root cause: Google saw /about with canonical=/about.html, creating a loop