### PR TITLE
seo: Bing compliance — title/description lengths + book meta desc

### DIFF
--- a/book.html
+++ b/book.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
+<meta name="description" content="Book your mobile auto detailing service with On-Wheels Detailing. Free quotes — serving Harris County TX and Metro Detroit MI.">
 <meta http-equiv="refresh" content="0;url=https://api.onwheelsdetailing.com/">
 <title>On-Wheels Detailing — Book Now</title>
 <link rel="canonical" href="https://api.onwheelsdetailing.com/">

--- a/contact.html
+++ b/contact.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <title>Contact On-Wheels Detailing | Free Quote for Auto Detailing</title>
-    <meta name="description" content="Contact TaSain at On-Wheels Detailing for a free quote on mobile auto detailing services. Serving Harris County TX and Metro Detroit MI. Get your free estimate today!">
+    <meta name="description" content="Contact TaSain at On-Wheels Detailing for a free quote on mobile auto detailing. Serving Harris County TX and Metro Detroit MI.">
     <meta name="keywords" content="contact detailing, detailing quote, mobile detailing Harris County, mobile detailing Texas, Metro Detroit detailing, Michigan detailing, free quote detailing">
     <meta name="author" content="On-Wheels Detailing">
     <meta name="robots" content="index, follow">

--- a/services.html
+++ b/services.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
-    <title>Detailing Services | On-Wheels Detailing - Interior & Paint Correction</title>
-    <meta name="description" content="Professional mobile auto detailing services including interior detailing, and paint correction. Serving Harris County TX and Metro Detroit MI. Free quotes available.">
+    <title>Detailing Services | On-Wheels Detailing</title>
+    <meta name="description" content="Professional mobile auto detailing — interior, paint correction, and ceramic coating. Serving Harris County TX and Metro Detroit MI. Free quotes.">
     <meta name="keywords" content="interior detailing, paint correction, ceramic coating, car detailing, mobile detailing Harris County, Metro Detroit detailing, Michigan detailing, Texas detailing">
     <meta name="author" content="On-Wheels Detailing">
     <meta name="robots" content="index, follow">


### PR DESCRIPTION
- services: title 72→41 chars, description 155→148 chars
- contact: description 175→128 chars
- book: added meta description (136 chars)
- gallery/about: false positives, no code change needed